### PR TITLE
CHK-425: Add pattern for BRA postal code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 

--- a/packages/bra/CHANGELOG.md
+++ b/packages/bra/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `pattern` to `postalCode` configuration.
 
 ## [0.1.0] - 2020-06-30
 ### Added

--- a/packages/bra/CHANGELOG.md
+++ b/packages/bra/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2020-11-04
 ### Added
 - Field `pattern` to `postalCode` configuration.
 

--- a/packages/bra/manifest.json
+++ b/packages/bra/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "country-data-bra",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "title": "Brazil Data for Places Components",
   "builders": {
     "vtex.country-data-settings": "0.x"

--- a/packages/bra/vtex.country-data-settings/configuration.json
+++ b/packages/bra/vtex.country-data-settings/configuration.json
@@ -159,6 +159,7 @@
     },
     "postalCode": {
       "mask": "99999-999",
+      "pattern": "^(\\d){5}-?(\\d){3}$",
       "label": "postalCode",
       "forgottenURL": "http://www.buscacep.correios.com.br/servicos/dnec/index.do"
     }


### PR DESCRIPTION
#### What problem is this solving?

Adds a pattern for Brazil's postalCode field.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

You can test in the cart postal code input.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
