### PR TITLE
CHK-470: Add `brief` display type to all countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Countries Data
 
+⚠️ **This is an ongoing, unsupported, unfinished and undocumented project. We do not guarantee any results after installation.** ⚠️
+
+<!-- DOCS-IGNORE:start -->
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+<!-- DOCS-IGNORE:end -->
+
 Monorepo containing the configuration apps for each country. These apps configure
 the [`vtex.country-data-settings`](https://github.com/vtex-apps/country-data-settings) service app,
 which is currently being used to power Checkout's profile and shipping forms.
@@ -20,3 +30,35 @@ which will be used to create the app name and the folder inside `./packages`.
 After running the script, you must then fill the configuration for that country inside
 `./packages/[country-code]/vtex.country-data-settings/configuration.json`. You can take a look
 at how this was done for other countries and go from there.
+
+## Releasing a new version
+
+Currently, VTEX IO CI/CD bots don't work on monorepos, so the release must be made manually.
+
+To release a new version, you must make sure to:
+
+1. update the version and date on `CHANGELOG.md`
+2. update the version field on `manifest.json`
+3. create a tagged release commit with `git tag -a "vtex.country-data-XXX@X.X.X" -m "vtex.country-data-XXX@X.X.X"`
+4. update your branch with `git push --tags origin your-branch`
+5. merge the PR after it's approved
+
+You may check an example by running `git show c7bbc4d`, which is a tagged release commit.
+
+<!-- DOCS-IGNORE:start -->
+
+## Contributors ✨
+
+Thanks goes to these wonderful people:
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
+
+<!-- DOCS-IGNORE:end -->

--- a/packages/arg/CHANGELOG.md
+++ b/packages/arg/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-01-20
+### Added
+- Add `brief` display type.
+
 ## [0.1.0] - 2020-06-30
 ### Added
 - Initial app configuration.

--- a/packages/arg/manifest.json
+++ b/packages/arg/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "country-data-arg",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "builders": {
     "vtex.country-data-settings": "0.x"
   },

--- a/packages/arg/vtex.country-data-settings/configuration.json
+++ b/packages/arg/vtex.country-data-settings/configuration.json
@@ -51,6 +51,13 @@
         }
       ]
     ],
+    "brief": [
+      [
+        { "name": "street" },
+        { "name": "number", "delimiter": ", " },
+        { "name": "neighborhood", "delimiter": " - " }
+      ]
+    ],
     "compact": [
       [
         {

--- a/packages/bol/CHANGELOG.md
+++ b/packages/bol/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-01-20
+### Added
+- Add `brief` display type.
+
 ## [0.1.0] - 2020-06-30
 ### Added
 - Initial app configuration.

--- a/packages/bol/manifest.json
+++ b/packages/bol/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "country-data-bol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "builders": {
     "vtex.country-data-settings": "0.x"
   },

--- a/packages/bol/vtex.country-data-settings/configuration.json
+++ b/packages/bol/vtex.country-data-settings/configuration.json
@@ -40,6 +40,13 @@
         }
       ]
     ],
+    "brief": [
+      [
+        { "name": "street" },
+        { "name": "number", "delimiter": ", " },
+        { "name": "neighborhood", "delimiter": " - " }
+      ]
+    ],
     "compact": [
       [
         {

--- a/packages/bra/CHANGELOG.md
+++ b/packages/bra/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2021-01-20
+### Added
+- Add `brief` display type.
+
 ## [0.2.1] - 2021-01-04
 ### Fixed
 - Invalid postal code locator URL.

--- a/packages/bra/manifest.json
+++ b/packages/bra/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "country-data-bra",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "title": "Brazil Data for Places Components",
   "builders": {
     "vtex.country-data-settings": "0.x"

--- a/packages/bra/vtex.country-data-settings/configuration.json
+++ b/packages/bra/vtex.country-data-settings/configuration.json
@@ -172,6 +172,13 @@
         }
       ]
     ],
+    "brief": [
+      [
+        { "name": "street" },
+        { "name": "number", "delimiter": ", " },
+        { "name": "neighborhood", "delimiter": " - " }
+      ]
+    ],
     "compact": [
       [
         {

--- a/packages/usa/CHANGELOG.md
+++ b/packages/usa/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-01-20
+### Added
+- Add `brief` display type.
+
 ## [0.1.0] - 2020-06-30
 ### Added
 - Initial app configuration.

--- a/packages/usa/manifest.json
+++ b/packages/usa/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "country-data-usa",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "builders": {
     "vtex.country-data-settings": "0.x"
   },

--- a/packages/usa/vtex.country-data-settings/configuration.json
+++ b/packages/usa/vtex.country-data-settings/configuration.json
@@ -269,6 +269,13 @@
         }
       ]
     ],
+    "brief": [
+      [
+        { "name": "number" },
+        { "name": "street", "delimiter": ", " },
+        { "name": "neighborhood", "delimiter": " - " }
+      ]
+    ],
     "compact": [
       [
         {


### PR DESCRIPTION
#### What problem is this solving?

In order to improve the UX when displaying place data, countries can now config a `brief` display, which is between `minimal` and `compact` display, in terms of content size.

#### How should this be manually tested?

[GraphQL query](https://geolocation--checkoutio.myvtex.com/_v/private/vtex.country-data-settings@0.3.0/graphiql/v1?query=%7B%0A%20%20braData%3A%20countryData(country%3A%20%22BRA%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20bolData%3A%20countryData(country%3A%20%22BOL%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20argData%3A%20countryData(country%3A%20%22ARG%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20usaData%3A%20countryData(country%3A%20%22USA%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)