### PR TITLE
fix(usa-address): rename field and remove duplicate field

### DIFF
--- a/packages/usa/CHANGELOG.md
+++ b/packages/usa/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2021-09-24
+### Changed
+- Updates address's `street` and `number` labels.
+### Fixed
+- Removed duplicate `city` field in extended mode
+
 ## [0.1.1] - 2021-07-05
 ### Changed
 - Updates address's `street` and `complement` labels.

--- a/packages/usa/manifest.json
+++ b/packages/usa/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "country-data-usa",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "builders": {
     "vtex.country-data-settings": "0.x"
   },

--- a/packages/usa/vtex.country-data-settings/configuration.json
+++ b/packages/usa/vtex.country-data-settings/configuration.json
@@ -232,11 +232,11 @@
       "maxLength": 100
     },
     "street": {
-      "label": "street",
+      "label": "streetRoadAvenue",
       "required": true
     },
     "number": {
-      "label": "number",
+      "label": "numberOption",
       "maxLength": 750,
       "hidden": true,
       "autoComplete": "off"
@@ -307,10 +307,6 @@
       [
         {
           "name": "number"
-        },
-        {
-          "delimiter": ", ",
-          "name": "city"
         },
         {
           "delimiter": ", ",


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Rename street and number field to work with `place-components` and remove duplicate `city` field in extended mode

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
